### PR TITLE
Fixed: multiple authors not displaying properly

### DIFF
--- a/src/components/BookCard/BookCard.jsx
+++ b/src/components/BookCard/BookCard.jsx
@@ -4,17 +4,18 @@ import thumbnail from '../../assets/icons8-book-64.png'
 const BookCard = (props) => {
   const {info} = props;
   const {authors, title, description, imageLinks} = info;
+  console.log(authors);
 
   return (
     <div className={style.BookCard}>
       <div className={style.BookCard__img}>
-        { imageLinks ? <img src={imageLinks['thumbnail']} alt={title}/> : <img src={thumbnail} /> }
+        { imageLinks ? <img src={imageLinks['thumbnail']} alt={title}/> : <img src={thumbnail} alt="No bookcover"/> }
       </div>
 
       <div className={style.BookCard__content}>
         <div className={[style.content, style.content__left].join(" ")}>
           <h2 className={style.content__title}>{title ? title : 'No title found'}</h2>
-          <h3 className={style.content__author}>{authors ? authors : 'No author found'}</h3> 
+          <h3 className={style.content__author}>{authors ? authors.join(", ") : 'No author found'}</h3> 
         </div>
 
         <div className={[style.content, style.content__right].join(" ")}>

--- a/src/containers/BookList/BookList.jsx
+++ b/src/containers/BookList/BookList.jsx
@@ -16,7 +16,7 @@ const [books] = useContext(BookContext);
   return (
     <>
     { books ? books.map(item => (
-        <BookCard id={item['id']} info={item['volumeInfo']} />
+        <BookCard key={item['id'] }id={item['id']} info={item['volumeInfo']} />
       )) : <NoResults />
     }
     {/* { books ? <Pagination /> : null } */}


### PR DESCRIPTION
Error: Having more than 1 author for a book would result in a string of authors displayed without spacing. 

Fixed via adding string.join(", "). 